### PR TITLE
Update 2 download-search-dataset-temporal-extent.req

### DIFF
--- a/source/http-examples/download-search-dataset-temporal-extent.req
+++ b/source/http-examples/download-search-dataset-temporal-extent.req
@@ -1,3 +1,3 @@
 GET /api/@search?portal_type=DataSet&metadata_fields=UID&metadata_fields=download_limit_temporal_extent&b_size=300 HTTP/1.1
-Host: land.copernicus.eu
+Host: https://land.copernicus.eu
 Accept: application/json


### PR DESCRIPTION
In the The download-search-dataset-temporal-extent.req host has been modified to indicate https.