### PR TITLE
Update 3 conf.py and download-search-dataset-temporal-extent.req

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -51,7 +51,7 @@ exclude_patterns = []
 
 # Adjusted the host and schema to be used in the examples.
 http_scheme = "https"
-http_host = "https://land.copernicus.eu"
+http_host = "land.copernicus.eu"
 
 # -- Substitutions Variables --------------------------------------------------
 myst_all_links_external = True

--- a/source/http-examples/download-search-dataset-temporal-extent.req
+++ b/source/http-examples/download-search-dataset-temporal-extent.req
@@ -1,3 +1,3 @@
 GET /api/@search?portal_type=DataSet&metadata_fields=UID&metadata_fields=download_limit_temporal_extent&b_size=300 HTTP/1.1
-Host: https://land.copernicus.eu
+Host: land.copernicus.eu
 Accept: application/json


### PR DESCRIPTION
In the conf.py file, http_scheme = "https" was added and the host was changed to http_host = "land.copernicus.eu"
In the download-search-dataset-temporal-extent.req file, the host was changed to its original value: Host: land.copernicus.eu