### PR TITLE
Update 5 download-search-dataset-temporal-extent.req

### DIFF
--- a/source/http-examples/download-search-dataset-temporal-extent.req
+++ b/source/http-examples/download-search-dataset-temporal-extent.req
@@ -1,2 +1,2 @@
-GET /api/@search?portal_type=DataSet&metadata_fields=UID&metadata_fields=download_limit_temporal_extent&b_size=300 HTTP/1.1
+GET /api/@search?portal_type=DataSet&metadata_fields=UID&metadata_fields=download_limit_temporal_extent&b_size=300
 Accept: application/json


### PR DESCRIPTION
Removed HTTP/1.1 from the download-search-dataset-temporal-extent.req file.