### PR TITLE
Update again download-search-dataset-temporal-extent.req

### DIFF
--- a/source/http-examples/download-search-dataset-temporal-extent.req
+++ b/source/http-examples/download-search-dataset-temporal-extent.req
@@ -1,3 +1,4 @@
-GET /api/@search?portal_type=DataSet&metadata_fields=UID&metadata_fields=download_limit_temporal_extent&b_size=300
-Host: land.copernicus.eu
+GET https://land.copernicus.eu/api/@search?portal_type=DataSet&metadata_fields=UID&metadata_fields=download_limit_temporal_extent&b_size=300
 Accept: application/json
+
+


### PR DESCRIPTION
The .req file was modified again to include the full URL and the host was removed because using the full URL is not necessary.