### PR TITLE
Update 9 again download-search-dataset-temporal-extent.req

### DIFF
--- a/source/http-examples/download-search-dataset-temporal-extent.req
+++ b/source/http-examples/download-search-dataset-temporal-extent.req
@@ -1,5 +1,5 @@
 GET https://land.copernicus.eu/api/@search?portal_type=DataSet&metadata_fields=UID&metadata_fields=download_limit_temporal_extent&b_size=300
-Host: land.copernicus.eu
+Host: 
 Accept: application/json
 
 


### PR DESCRIPTION
The .req file was modified again to include the full URL and add the host, but left blank.