### PR TITLE
Update .github/workflows/docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade -r requirements.txt
+          pip show sphinxcontrib-httpexample
 
       # Build
       - uses: ammaraskar/sphinx-problem-matcher@master


### PR DESCRIPTION
This line was included: pip show sphinxcontrib-httpexample to see the version of **sphinxcontrib-httpexample** in the log