### PR TITLE
Update conf.py and http-examples *.req files

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -52,7 +52,6 @@ exclude_patterns = []
 
 # Adjusted the host and schema to be used in the examples.
 httpexample_scheme = 'https'
-#http_scheme = "https"
 http_host = "land.copernicus.eu"
 
 # -- Substitutions Variables --------------------------------------------------

--- a/source/http-examples/download-auxiliary_api_landcover.req
+++ b/source/http-examples/download-auxiliary_api_landcover.req
@@ -1,4 +1,4 @@
 GET /api/@get-download-file-urls?dataset_uid=a08da3f50c8d4b38bec35b831382162b&download_information_id=00058a15-088e-4461-9c35-b6d4467f34ca HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 Authorization: Bearer <REDACTED>

--- a/source/http-examples/download-auxiliary_api_legacy.req
+++ b/source/http-examples/download-auxiliary_api_legacy.req
@@ -1,4 +1,4 @@
 GET /api/@get-download-file-urls?dataset_uid=58b4d790fc6b435d9e61c48d14bc06bb&download_information_id=27062663-bba6-43c1-8c73-c7ed82814956&date_from=2017-01-01&date_to=2017-03-07 HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 Authorization: Bearer <REDACTED>

--- a/source/http-examples/download-auxiliary_api_wekeo.req
+++ b/source/http-examples/download-auxiliary_api_wekeo.req
@@ -1,4 +1,4 @@
 GET /api/@get-download-file-urls?dataset_uid=8d14c6a2ba7946faaaf50e4e8241fe1c&download_information_id=2c51dd60-0e70-4ff8-88c0-bd8cb6c58123 HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 Authorization: Bearer <REDACTED>

--- a/source/http-examples/download-available-conversions.req
+++ b/source/http-examples/download-available-conversions.req
@@ -1,4 +1,4 @@
 GET /api/@format_conversion_table HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 Authorization: Bearer <REDACTED>

--- a/source/http-examples/download-available-projections.req
+++ b/source/http-examples/download-available-projections.req
@@ -1,4 +1,4 @@
 GET /api/@projections?uid=0407d497d3c44bcd93ce8fd5bf78596a HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 Authorization: Bearer <REDACTED>

--- a/source/http-examples/download-request-combined.req
+++ b/source/http-examples/download-request-combined.req
@@ -1,5 +1,5 @@
 POST /api/@datarequest_post HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 Content-type: application/json
 Authorization: Bearer <REDACTED>

--- a/source/http-examples/download-request-delete.req
+++ b/source/http-examples/download-request-delete.req
@@ -1,5 +1,5 @@
 DELETE /api/@datarequest_delete HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 Content-type: application/json
 Authorization: Bearer <REDACTED>

--- a/source/http-examples/download-request-download-bbox.req
+++ b/source/http-examples/download-request-download-bbox.req
@@ -1,5 +1,5 @@
 POST /api/@datarequest_post HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 Content-type: application/json
 Authorization: Bearer <REDACTED>

--- a/source/http-examples/download-request-download-finished.req
+++ b/source/http-examples/download-request-download-finished.req
@@ -1,4 +1,4 @@
 GET /api/@datarequest_search?status=Finished_ok HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 Authorization: Bearer <REDACTED>

--- a/source/http-examples/download-request-download-full_dataset_ok.req
+++ b/source/http-examples/download-request-download-full_dataset_ok.req
@@ -1,5 +1,5 @@
 POST /api/@datarequest_post HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 Content-type: application/json
 Authorization: Bearer <REDACTED>

--- a/source/http-examples/download-request-download-in-progress.req
+++ b/source/http-examples/download-request-download-in-progress.req
@@ -1,4 +1,4 @@
 GET /api/@datarequest_search?status=In_progress HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 Authorization: Bearer <REDACTED>

--- a/source/http-examples/download-request-download-layers-timeseries.req
+++ b/source/http-examples/download-request-download-layers-timeseries.req
@@ -1,5 +1,5 @@
 POST /api/@datarequest_post HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 Content-type: application/json
 Authorization: Bearer <REDACTED>

--- a/source/http-examples/download-request-download-nuts-restriction.req
+++ b/source/http-examples/download-request-download-nuts-restriction.req
@@ -1,5 +1,5 @@
 POST /api/@datarequest_post HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 Content-type: application/json
 Authorization: Bearer <REDACTED>

--- a/source/http-examples/download-request-download-nuts-timeseries.req
+++ b/source/http-examples/download-request-download-nuts-timeseries.req
@@ -1,5 +1,5 @@
 POST /api/@datarequest_post HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 Content-type: application/json
 Authorization: Bearer <REDACTED>

--- a/source/http-examples/download-request-download-prepackaged.req
+++ b/source/http-examples/download-request-download-prepackaged.req
@@ -1,5 +1,5 @@
 POST /api/@datarequest_post HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 Content-type: application/json
 Authorization: Bearer <REDACTED>

--- a/source/http-examples/download-request-download-status.req
+++ b/source/http-examples/download-request-download-status.req
@@ -1,4 +1,4 @@
 GET /api/@datarequest_status_get?TaskID=14909741217 HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 Authorization: Bearer <REDACTED>

--- a/source/http-examples/download-request-download-timeseries.req
+++ b/source/http-examples/download-request-download-timeseries.req
@@ -1,5 +1,5 @@
 POST /api/@datarequest_post HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 Content-type: application/json
 Authorization: Bearer <REDACTED>

--- a/source/http-examples/download-search-dataset-temporal-extent.req
+++ b/source/http-examples/download-search-dataset-temporal-extent.req
@@ -1,3 +1,3 @@
-GET /api/@search?portal_type=DataSet&metadata_fields=UID&metadata_fields=download_limit_temporal_extent&b_size=300
+GET /api/@search?portal_type=DataSet&metadata_fields=UID&metadata_fields=download_limit_temporal_extent&b_size=300 HTTP/1.1
 Host: land.copernicus.eu
 Accept: application/json

--- a/source/http-examples/download-search-datasets.req
+++ b/source/http-examples/download-search-datasets.req
@@ -1,4 +1,4 @@
 GET /api/@search?portal_type=DataSet&metadata_fields=UID&metadata_fields=dataset_full_format&&metadata_fields=dataset_download_information HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json
 


### PR DESCRIPTION
In the following files, the / at the end of the Host header was removed to avoid duplicating the //
        modified:   source/http-examples/download-auxiliary_api_landcover.req
        modified:   source/http-examples/download-auxiliary_api_legacy.req
        modified:   source/http-examples/download-auxiliary_api_wekeo.req
        modified:   source/http-examples/download-available-conversions.req
        modified:   source/http-examples/download-available-projections.req
        modified:   source/http-examples/download-request-combined.req
        modified:   source/http-examples/download-request-delete.req
        modified:   source/http-examples/download-request-download-bbox.req
        modified:   source/http-examples/download-request-download-finished.req
        modified:   source/http-examples/download-request-download-full_dataset_ok.req
        modified:   source/http-examples/download-request-download-in-progress.req
        modified:   source/http-examples/download-request-download-layers-timeseries.req
        modified:   source/http-examples/download-request-download-nuts-restriction.req
        modified:   source/http-examples/download-request-download-nuts-timeseries.req
        modified:   source/http-examples/download-request-download-prepackaged.req
        modified:   source/http-examples/download-request-download-status.req
        modified:   source/http-examples/download-request-download-timeseries.req
        modified:   source/http-examples/download-search-dataset-temporal-extent.req
        modified:   source/http-examples/download-search-datasets.req
In the **conf.py** file, the line http_scheme = 'https' was removed because it was not necessary
