### PR TITLE
Update  source/http-examples/download-search-dataset-prepackaged.req

### DIFF
--- a/source/http-examples/download-search-dataset-prepackaged.req
+++ b/source/http-examples/download-search-dataset-prepackaged.req
@@ -1,3 +1,3 @@
 GET /api/@search?portal_type=DataSet&metadata_fields=UID&metadata_fields=downloadable_files HTTP/1.1
-Host: land.copernicus.eu/
+Host: land.copernicus.eu
 Accept: application/json


### PR DESCRIPTION
The slash / at the end of the Host header was removed to prevent duplication.